### PR TITLE
Add labels and deletion protection to self-managed certificate examples

### DIFF
--- a/examples/self-managed/main.tf
+++ b/examples/self-managed/main.tf
@@ -2,7 +2,10 @@ module "testsecret" {
   source = "git::https://github.com/terraform-yacloud-modules/terraform-yandex-lockbox.git?ref=v1.0.0"
 
   name   = "testsecret"
-  labels = {}
+  labels = {
+    environment = "test"
+    project     = "certificate-manager"
+  }
 
   entries = {
     "key-a" : "value-a"
@@ -20,6 +23,11 @@ module "self_managed" {
       description = "self-managed domain certificate from file"
       certificate = file("cert.pem")
       private_key = file("key.pem")
+      labels = {
+        type        = "self-managed"
+        environment = "test"
+      }
+      deletion_protection = false
     }
     example-com = {
       description = "self-managed domain certificate from lockbox"
@@ -28,6 +36,12 @@ module "self_managed" {
         id  = module.testsecret.id
         key = "key-pem"
       }
+      labels = {
+        type        = "self-managed"
+        source      = "lockbox"
+        environment = "test"
+      }
+      deletion_protection = false
     }
   }
 


### PR DESCRIPTION
Добавлены метки и защита от удаления в примерах самоуправляемых сертификатов

- В модуль `testsecret` добавлены метки `environment` и `project`  
- Для самоуправляемых сертификатов добавлены метки, указывающие тип, источник и окружение  
- Для всех сертификатов включена защита от удаления (`deletion_protection = false`)  